### PR TITLE
Add simple makefile with helpful dev tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+all: test
+
+prepare:
+	# needed for `make fmt`
+	go get golang.org/x/tools/cmd/goimports
+	#linters
+	go get github.com/alecthomas/gometalinter
+	gometalinter --install
+	@echo Now you should be ready to run "make"
+
+test:
+	@go test -parallel 4 ./...
+
+# goimports produces slightly different formatted code from go fmt
+fmt:
+	find . -name "*.go" -exec goimports -w {} \;
+
+lint:
+	gometalinter
+
+cover:
+	go test -cover -coverprofile cover.out
+	go tool cover -html=cover.out
+
+.PHONY: all prepare test fmt lint cover


### PR DESCRIPTION
Adds a makefile with tasks for auto-formatting code and running [gometalinter](https://github.com/alecthomas/gometalinter) to find possible bugs via static analysis tools.  You'll need to run `make prepare` once and then you can run `make` (to run tests), `make fmt`, `make lint`, etc.
