### PR TITLE
Make newError function public

### DIFF
--- a/error.go
+++ b/error.go
@@ -28,6 +28,10 @@ func (e Error) Error() string {
 	return e.Message
 }
 
+func NewError(msg interface{}) Error {
+	return newError(msg, 2)
+}
+
 func newError(thing interface{}, stackOffset int) Error {
 	var err error
 

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,22 @@
+package honeybadger
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewErrorTrace(t *testing.T) {
+	fn := func() Error {
+		return NewError("Error msg")
+	}
+
+	err := fn()
+	if len(err.Stack) < 3 {
+		t.Errorf("Expected to generate full trace")
+	}
+
+	method := strings.Split(err.Stack[1].Method, ".")
+	if method[len(method)-1] != "TestNewErrorTrace" {
+		t.Errorf("Expected to generate a proper trace")
+	}
+}


### PR DESCRIPTION
When you don't send an error to honeybadger straightaway, you lose the trace.
Having a public `NewError` method, you can wrap your error to get a proper trace.

For instance:
```go
func one() {
    if err := two(); err != nil {
        honeybadger.Notify(err)
    }
}

func two() error {
    return three()
}

func three() error {
    return errors.New("Error")
}
```
In this case we won't see that error happened in function `three`.

However, having an access to `NewError` we can keep the trace:
```go
func three() error {
    err := errors.New("Error")
    return honeybadger.NewError(err, 0)
}
```