### PR TITLE
Use GitHub uuid package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: test
 
 prepare:
 	# dependencies
-	go get code.google.com/p/go-uuid/uuid
+	go get github.com/pborman/uuid
 	go get github.com/shirou/gopsutil/load
 	# needed for `make fmt`
 	go get golang.org/x/tools/cmd/goimports

--- a/honeybadger_test.go
+++ b/honeybadger_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 )
 
 var (

--- a/notice.go
+++ b/notice.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"time"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"github.com/shirou/gopsutil/load"
 	"github.com/shirou/gopsutil/mem"
 )


### PR DESCRIPTION
The go-uuid/uuid package on code.google.com has been [archived and moved] to
https://github.com/pborman/uuid.

Google Code itself has been sunset:
https://code.google.com/p/support/wiki/ReadOnlyTransition

[archived and moved]: https://code.google.com/archive/p/go-uuid/