### PR TITLE
Request Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Added
+- Use `honeybadger.MetricsHandler` to send us request metrics!
 
 ## [0.0.3] - 2016-04-13
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ prepare: deps
 	gometalinter --install
 	# needed for `make cover`
 	go get golang.org/x/tools/cmd/cover
+	# testing libs
+	go get github.com/stretchr/testify/mock
+	go get github.com/stretchr/testify/assert
 	@echo Now you should be ready to run "make"
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ deps:
 	# dependencies
 	go get github.com/pborman/uuid
 	go get github.com/shirou/gopsutil/load
+	# testing libs
+	go get github.com/stretchr/testify/mock
+	go get github.com/stretchr/testify/assert
 
 prepare: deps
 	# needed for `make fmt`
@@ -13,9 +16,6 @@ prepare: deps
 	gometalinter --install
 	# needed for `make cover`
 	go get golang.org/x/tools/cmd/cover
-	# testing libs
-	go get github.com/stretchr/testify/mock
-	go get github.com/stretchr/testify/assert
 	@echo Now you should be ready to run "make"
 
 test:

--- a/README.md
+++ b/README.md
@@ -50,17 +50,6 @@ errors which happen inside `honeybadger.Handler`. Make sure you recover from
 panics after honeybadger's Handler has been executed to ensure all panics are
 reported.
 
-### 4. Enable performance monitoring (Medium+ plans only)
-
-If your plan supports performance monitoring, you can set up your app to send
-request metrics using `honeybadger.MetricsHandler`. You can wrap any existing
-handlers, including `honeybadger.Handler` for error reporting:
-
-```go
-monitoredHandler := honeybadger.MetricsHandler(honeybadger.Handler(handler))
-log.Fatal(http.ListenAndServe(":8080", monitoredHandler)
-```
-
 #### Unhandled Panics
 
 
@@ -82,6 +71,17 @@ To report an error manually, use `honeybadger.Notify`:
 if err != nil {
   honeybadger.Notify(err)
 }
+```
+
+### 4. Enable performance monitoring (Medium+ plans only)
+
+If your plan supports performance monitoring, you can set up your app to send
+request metrics using `honeybadger.MetricsHandler`. You can wrap any existing
+handlers, including `honeybadger.Handler` for error reporting:
+
+```go
+monitoredHandler := honeybadger.MetricsHandler(honeybadger.Handler(handler))
+log.Fatal(http.ListenAndServe(":8080", monitoredHandler)
 ```
 
 ## Sample Application

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ errors which happen inside `honeybadger.Handler`. Make sure you recover from
 panics after honeybadger's Handler has been executed to ensure all panics are
 reported.
 
+### 4. Enable performance monitoring (Medium+ plans only)
+
+If your plan supports performance monitoring, you can set up your app to send
+request metrics using `honeybadger.MetricsHandler`. You can wrap any existing
+handlers, including `honeybadger.Handler` for error reporting:
+
+```go
+monitoredHandler := honeybadger.MetricsHandler(honeybadger.Handler(handler))
+log.Fatal(http.ListenAndServe(":8080", monitoredHandler)
+```
+
 #### Unhandled Panics
 
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The following options are available to you:
 | Timeout | `time.Duration` | 3 seconds | `10 * time.Second` | `HONEYBADGER_TIMEOUT` (nanoseconds) |
 | Logger | `honeybadger.Logger` | Logs to stderr | `CustomLogger{}` | n/a |
 | Backend | `honeybadger.Backend` | HTTP backend | `CustomBackend{}` | n/a |
+| MetricsInterval | `time.Duration` | 60 seconds | `60 * time.Second` | n/a |
 
 
 ## Public Interface

--- a/configuration.go
+++ b/configuration.go
@@ -15,14 +15,15 @@ type Logger interface {
 
 // Configuration manages the configuration for the client.
 type Configuration struct {
-	APIKey   string
-	Root     string
-	Env      string
-	Hostname string
-	Endpoint string
-	Timeout  time.Duration
-	Logger   Logger
-	Backend  Backend
+	APIKey          string
+	Root            string
+	Env             string
+	Hostname        string
+	Endpoint        string
+	Timeout         time.Duration
+	Logger          Logger
+	Backend         Backend
+	MetricsInterval time.Duration
 }
 
 func (c1 *Configuration) update(c2 *Configuration) *Configuration {
@@ -50,18 +51,22 @@ func (c1 *Configuration) update(c2 *Configuration) *Configuration {
 	if c2.Backend != nil {
 		c1.Backend = c2.Backend
 	}
+	if c2.MetricsInterval > 0 {
+		c1.MetricsInterval = c2.MetricsInterval
+	}
 	return c1
 }
 
 func newConfig(c Configuration) *Configuration {
 	config := &Configuration{
-		APIKey:   getEnv("HONEYBADGER_API_KEY"),
-		Root:     getPWD(),
-		Env:      getEnv("HONEYBADGER_ENV"),
-		Hostname: getHostname(),
-		Endpoint: getEnv("HONEYBADGER_ENDPOINT", "https://api.honeybadger.io"),
-		Timeout:  getTimeout(),
-		Logger:   log.New(os.Stderr, "[honeybadger] ", log.Flags()),
+		APIKey:          getEnv("HONEYBADGER_API_KEY"),
+		Root:            getPWD(),
+		Env:             getEnv("HONEYBADGER_ENV"),
+		Hostname:        getHostname(),
+		Endpoint:        getEnv("HONEYBADGER_ENDPOINT", "https://api.honeybadger.io"),
+		Timeout:         getTimeout(),
+		Logger:          log.New(os.Stderr, "[honeybadger] ", log.Flags()),
+		MetricsInterval: 60 * time.Second,
 	}
 	config.update(&c)
 

--- a/honeybadger.go
+++ b/honeybadger.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // VERSION defines the version of the honeybadger package.
@@ -109,4 +110,9 @@ func BeforeNotify(handler func(notice *Notice) error) {
 // 60 seconds.
 func Increment(metric string, value int) {
 	DefaultClient.Increment(metric, value)
+}
+
+// Timing records a timing metric.
+func Timing(metric string, value time.Duration) {
+	DefaultClient.Timing(metric, value)
 }

--- a/honeybadger.go
+++ b/honeybadger.go
@@ -1,6 +1,7 @@
 package honeybadger
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/url"
 )
@@ -17,6 +18,9 @@ var (
 
 	// Notices is the feature for sending error reports.
 	Notices = Feature{"notices"}
+
+	// Metrics is the feature for sending metrics.
+	Metrics = Feature{"metrics"}
 )
 
 // Feature references a resource provided by the API service. Its Endpoint maps
@@ -33,6 +37,17 @@ type CGIData hash
 
 // Params stores the form or url values from an HTTP request.
 type Params url.Values
+
+// hash is used internally to construct JSON payloads.
+type hash map[string]interface{}
+
+func (h *hash) toJSON() []byte {
+	out, err := json.Marshal(h)
+	if err == nil {
+		return out
+	}
+	panic(err)
+}
 
 // Configure updates configuration of the global client.
 func Configure(c Configuration) {
@@ -88,4 +103,10 @@ func Handler(h http.Handler) http.Handler {
 // will be skipped, otherwise it will be sent.
 func BeforeNotify(handler func(notice *Notice) error) {
 	DefaultClient.BeforeNotify(handler)
+}
+
+// Increment increments a counter metric. Metrics are sent to Honeybadger every
+// 60 seconds.
+func Increment(metric string, value int) {
+	DefaultClient.Increment(metric, value)
 }

--- a/honeybadger.go
+++ b/honeybadger.go
@@ -99,6 +99,12 @@ func Handler(h http.Handler) http.Handler {
 	return DefaultClient.Handler(h)
 }
 
+// MetricsHandler returns an http.Handler function which automatically reports
+// request metrics to Honeybadger.
+func MetricsHandler(h http.Handler) http.Handler {
+	return DefaultClient.MetricsHandler(h)
+}
+
 // BeforeNotify adds a callback function which is run before a notice is
 // reported to Honeybadger. If any function returns an error the notification
 // will be skipped, otherwise it will be sent.

--- a/honeybadger_test.go
+++ b/honeybadger_test.go
@@ -263,17 +263,29 @@ func testNoticePayload(t *testing.T, payload hash) bool {
 	return true
 }
 
-func TestMetricsHandlerCallsHandler(t *testing.T) {
-	handler := &MockedHandler{}
-	handler.On("ServeHTTP").Return()
+func TestHandlerCallsHandler(t *testing.T) {
+	mockHandler := &MockedHandler{}
+	mockHandler.On("ServeHTTP").Return()
 
-	metricsHandler := MetricsHandler(handler)
+	handler := Handler(mockHandler)
+	req, _ := http.NewRequest("GET", "", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	mockHandler.AssertCalled(t, "ServeHTTP")
+}
+
+func TestMetricsHandlerCallsHandler(t *testing.T) {
+	mockHandler := &MockedHandler{}
+	mockHandler.On("ServeHTTP").Return()
+
+	metricsHandler := MetricsHandler(mockHandler)
 
 	req, _ := http.NewRequest("GET", "", nil)
 	w := httptest.NewRecorder()
 	metricsHandler.ServeHTTP(w, req)
 
-	handler.AssertCalled(t, "ServeHTTP")
+	mockHandler.AssertCalled(t, "ServeHTTP")
 }
 
 func assertMethod(t *testing.T, r *http.Request, method string) {

--- a/honeybadger_test.go
+++ b/honeybadger_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/mock"
 )
 
 var (
@@ -18,6 +19,14 @@ var (
 	requests      []*HTTPRequest
 	defaultConfig = *Config
 )
+
+type MockedHandler struct {
+	mock.Mock
+}
+
+func (h *MockedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.Called()
+}
 
 type HTTPRequest struct {
 	Request *http.Request
@@ -252,6 +261,19 @@ func testNoticePayload(t *testing.T, payload hash) bool {
 		}
 	}
 	return true
+}
+
+func TestMetricsHandlerCallsHandler(t *testing.T) {
+	handler := &MockedHandler{}
+	handler.On("ServeHTTP").Return()
+
+	metricsHandler := MetricsHandler(handler)
+
+	req, _ := http.NewRequest("GET", "", nil)
+	w := httptest.NewRecorder()
+	metricsHandler.ServeHTTP(w, req)
+
+	handler.AssertCalled(t, "ServeHTTP")
 }
 
 func assertMethod(t *testing.T, r *http.Request, method string) {

--- a/metric_collector.go
+++ b/metric_collector.go
@@ -10,18 +10,31 @@ type counterMetric struct {
 	value int
 }
 
+type timingMetric struct {
+	name  string
+	value time.Duration
+}
+
 type metricCollector struct {
-	counter chan counterMetric
+	counter  chan counterMetric
+	timingCh chan timingMetric
 }
 
 func (c *metricCollector) increment(metric string, value int) {
-	c.counter <- counterMetric{name: metric, value: value}
+	c.counter <- counterMetric{metric, value}
+}
+
+func (c *metricCollector) timing(metric string, value time.Duration) {
+	c.timingCh <- timingMetric{metric, value}
 }
 
 func newMetricCollector(config *Configuration, worker worker) *metricCollector {
 	counter := make(chan counterMetric)
+	timing := make(chan timingMetric)
+
 	go func() {
 		flush := make(chan int)
+
 		go func() {
 			for {
 				time.Sleep(config.MetricsInterval)
@@ -30,19 +43,34 @@ func newMetricCollector(config *Configuration, worker worker) *metricCollector {
 		}()
 
 		counters := make(map[string]int)
+		timings := make(map[string][]time.Duration)
+
 		for {
 			select {
 			case metric := <-counter:
 				counters[metric.name] += metric.value
+			case metric := <-timing:
+				timings[metric.name] = append(timings[metric.name], metric.value)
 			case <-flush:
-				if len(counters) <= 0 {
+				if len(counters) <= 0 && len(timings) <= 0 {
 					break
 				}
 				metrics := []string{}
 				for name, value := range counters {
 					metrics = append(metrics, fmt.Sprintf("%v %v", name, value))
 				}
+				for name, values := range timings {
+					mean := mean(values)
+					metrics = append(metrics, fmt.Sprintf("%v:mean %v", name, mean))
+					metrics = append(metrics, fmt.Sprintf("%v:median %v", name, median(values)))
+					metrics = append(metrics, fmt.Sprintf("%v:percentile_90 %v", name, percentile(values, 90)))
+					metrics = append(metrics, fmt.Sprintf("%v:min %v", name, min(values)))
+					metrics = append(metrics, fmt.Sprintf("%v:max %v", name, max(values)))
+					metrics = append(metrics, fmt.Sprintf("%v:stddev %v", name, stdDev(values, mean)))
+					metrics = append(metrics, fmt.Sprintf("%v %v", name, len(values)))
+				}
 				counters = make(map[string]int)
+				timings = make(map[string][]time.Duration)
 				payload := &hash{
 					"metrics":     metrics,
 					"environment": config.Env,
@@ -61,5 +89,5 @@ func newMetricCollector(config *Configuration, worker worker) *metricCollector {
 		}
 	}()
 
-	return &metricCollector{counter: counter}
+	return &metricCollector{counter, timing}
 }

--- a/metric_collector.go
+++ b/metric_collector.go
@@ -1,0 +1,65 @@
+package honeybadger
+
+import (
+	"fmt"
+	"time"
+)
+
+type counterMetric struct {
+	name  string
+	value int
+}
+
+type metricCollector struct {
+	counter chan counterMetric
+}
+
+func (c *metricCollector) increment(metric string, value int) {
+	c.counter <- counterMetric{name: metric, value: value}
+}
+
+func newMetricCollector(config *Configuration, worker worker) *metricCollector {
+	counter := make(chan counterMetric)
+	go func() {
+		flush := make(chan int)
+		go func() {
+			for {
+				time.Sleep(config.MetricsInterval)
+				flush <- 1
+			}
+		}()
+
+		counters := make(map[string]int)
+		for {
+			select {
+			case metric := <-counter:
+				counters[metric.name] += metric.value
+			case <-flush:
+				if len(counters) <= 0 {
+					break
+				}
+				metrics := []string{}
+				for name, value := range counters {
+					metrics = append(metrics, fmt.Sprintf("%v %v", name, value))
+				}
+				counters = make(map[string]int)
+				payload := &hash{
+					"metrics":     metrics,
+					"environment": config.Env,
+					"hostname":    config.Hostname,
+				}
+				workerErr := worker.Push(func() error {
+					if err := config.Backend.Notify(Metrics, payload); err != nil {
+						return err
+					}
+					return nil
+				})
+				if workerErr != nil {
+					config.Logger.Printf("worker error: %v feature=metrics\n", workerErr)
+				}
+			}
+		}
+	}()
+
+	return &metricCollector{counter: counter}
+}

--- a/notice.go
+++ b/notice.go
@@ -12,8 +12,6 @@ import (
 	"github.com/shirou/gopsutil/mem"
 )
 
-type hash map[string]interface{}
-
 // ErrorClass represents the class name of the error which is sent to
 // Honeybadger.
 type ErrorClass struct {

--- a/response_writer.go
+++ b/response_writer.go
@@ -1,0 +1,17 @@
+package honeybadger
+
+import "net/http"
+
+type responseWriter struct {
+	status int
+	http.ResponseWriter
+}
+
+func (w *responseWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func newResponseWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{http.StatusOK, w}
+}

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,82 @@
+package honeybadger
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+type durationSlice []time.Duration
+
+func (a durationSlice) Len() int           { return len(a) }
+func (a durationSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a durationSlice) Less(i, j int) bool { return int64(a[i]) < int64(a[j]) }
+
+func mean(values []time.Duration) float64 {
+	if len(values) < 1 {
+		return 0.0
+	}
+	total := 0.0
+	for _, v := range values {
+		total += float64(v)
+	}
+	return (total / float64(len(values))) / float64(time.Millisecond)
+}
+
+func median(values []time.Duration) float64 {
+	if len(values) < 1 {
+		return 0.0
+	}
+	middle := len(values) / 2
+	result := values[middle]
+	if len(values)%2 == 0 {
+		result = (result + values[middle-1]) / 2
+	}
+	return float64(result) / float64(time.Millisecond)
+}
+
+func stdDev(values []time.Duration, mean float64) float64 {
+	// Standard deviation requires at least 2 values.
+	if len(values) <= 1 {
+		return 0.0
+	}
+	total := 0.0
+	for _, value := range values {
+		total += math.Pow((float64(value)/float64(time.Millisecond))-mean, 2)
+	}
+	variance := total / float64(len(values)-1)
+	return math.Sqrt(variance)
+}
+
+func round(f float64) int {
+	return int(f + math.Copysign(0.5, f))
+}
+
+func percentile(values []time.Duration, threshold int) float64 {
+	if len(values) < 1 {
+		return 0.0
+	}
+	if len(values) == 1 {
+		return float64(values[0]) / float64(time.Millisecond)
+	}
+	sort.Sort(durationSlice(values))
+	index := int(math.Floor((float64(threshold)/100.00)*float64(len(values)))) + 1
+	values = values[0:index]
+	return float64(values[len(values)-1]) / float64(time.Millisecond)
+}
+
+func min(values []time.Duration) float64 {
+	if len(values) < 1 {
+		return 0.0
+	}
+	sort.Sort(durationSlice(values))
+	return float64(values[0]) / float64(time.Millisecond)
+}
+
+func max(values []time.Duration) float64 {
+	if len(values) < 1 {
+		return 0.0
+	}
+	sort.Sort(durationSlice(values))
+	return float64(values[len(values)-1]) / float64(time.Millisecond)
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,110 @@
+package honeybadger
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPercentileEmpty(t *testing.T) {
+	values := []time.Duration{}
+	percentile_90 := percentile(values, 90)
+	if percentile_90 != 0.0 {
+		t.Errorf("Expected percentile to return 0.0 for no values.")
+	}
+}
+
+func TestPercentileOne(t *testing.T) {
+	values := []time.Duration{time.Millisecond}
+	percentile_90 := percentile(values, 90)
+	if percentile_90 != 1.0 {
+		t.Errorf("Expected percentile %v but %v was returned.", 1.0, percentile_90)
+	}
+}
+
+func TestPercentile(t *testing.T) {
+	values := make([]time.Duration, 100)
+	// 0..100
+	for i := 0; i < 100; i++ {
+		values[i] = time.Duration(i) * time.Millisecond
+	}
+	percentile_90 := percentile(values, 90)
+	if percentile_90 != 90 {
+		t.Errorf("Expected percentile %v but %v was returned.", 90, percentile_90)
+	}
+}
+
+func TestMean(t *testing.T) {
+	values := make([]time.Duration, 6)
+	// 1, 2, 3, 4, 5
+	for i := 1; i < 7; i++ {
+		values[i-1] = time.Duration(i) * time.Millisecond
+	}
+	result := mean(values)
+	if result != 3.5 {
+		t.Errorf("Expected mean %v but %v was returned.", 3.5, result)
+	}
+}
+
+func TestMedian(t *testing.T) {
+	values := make([]time.Duration, 7)
+	// 1, 2, 3, 4, 5, 6, 7
+	for i := 1; i < 8; i++ {
+		values[i-1] = time.Duration(i) * time.Millisecond
+	}
+	result := median(values)
+	if result != 4 {
+		t.Errorf("Expected median %v but %v was returned.", 4, result)
+	}
+}
+
+func TestStdDevEmpty(t *testing.T) {
+	values := []time.Duration{}
+	result := stdDev(values, mean(values))
+	if result != 0.0 {
+		t.Errorf("Expected stdDev to return 0.0 for no values.")
+	}
+}
+
+func TestStdDevOne(t *testing.T) {
+	values := []time.Duration{3 * time.Millisecond}
+	result := stdDev(values, mean(values))
+	if result != 0.0 {
+		t.Errorf("Expected stdDev to return 0.0 for one value.")
+	}
+}
+
+func TestStdDev(t *testing.T) {
+	values := make([]time.Duration, 100)
+	// 0..100
+	for i := 0; i < 100; i++ {
+		values[i] = time.Duration(i) * time.Millisecond
+	}
+	result := stdDev(values, mean(values))
+	if result != 29.011491975882016 {
+		t.Errorf("Expected stdDev %v but %v was returned.", 29.011491975882016, result)
+	}
+}
+
+func TestMin(t *testing.T) {
+	values := make([]time.Duration, 6)
+	// 1, 2, 3, 4, 5, 6
+	for i := 1; i < 7; i++ {
+		values[i-1] = time.Duration(i) * time.Millisecond
+	}
+	result := min(values)
+	if result != 1 {
+		t.Errorf("Expected min 1 but %v was returned.", result)
+	}
+}
+
+func TestMax(t *testing.T) {
+	values := make([]time.Duration, 6)
+	// 1, 2, 3, 4, 5, 6
+	for i := 1; i < 7; i++ {
+		values[i-1] = time.Duration(i) * time.Millisecond
+	}
+	result := max(values)
+	if result != 6 {
+		t.Errorf("Expected max 6 but %v was returned.", result)
+	}
+}


### PR DESCRIPTION
This sends app.request.200, app.request.500, etc. metrics to Honeybadger so that the metrics tab is populated. Traces (slow requests) are not sent yet. This feature is enabled by wrapping your `http.Handler` in `honeybadger.MetricHandler()`.