### PR TITLE
Export Fingerprint fields

### DIFF
--- a/notice.go
+++ b/notice.go
@@ -23,11 +23,11 @@ type ErrorClass struct {
 // Fingerprint represents the fingerprint of the error, which controls grouping
 // in Honeybadger.
 type Fingerprint struct {
-	content string
+	Content string
 }
 
 func (f *Fingerprint) String() string {
-	return f.content
+	return f.Content
 }
 
 // Notice is a representation of the error which is sent to Honeybadger, and


### PR DESCRIPTION
I am using this library in one of my golang projects and I ran into this error when trying to use `honeybadger.Fingerprint`:
Error: `implicit assignment of unexported field 'content' in honeybadger.Fingerprint literal`.
My code: `honeybadger.Notify(errMsg, honeybadger.Fingerprint{"Testing"})`

This should fix that issue.