### PR TITLE
Add a NullBackend which is used to disable reporting errors.

### DIFF
--- a/null_backend.go
+++ b/null_backend.go
@@ -1,0 +1,20 @@
+package honeybadger
+
+// nullBackend implements the Backend interface but swallows errors and does not
+// send them to Honeybadger.
+type nullBackend struct{}
+
+// Ensure nullBackend implements Backend.
+var _ Backend = &nullBackend{}
+
+// NewNullBackend creates a backend which swallows all errors and does not send
+// them to Honeybadger. This is useful for development and testing to disable
+// sending unnecessary errors.
+func NewNullBackend() Backend {
+	return nullBackend{}
+}
+
+// Notify swallows error reports, does nothing, and returns no error.
+func (b nullBackend) Notify(_ Feature, _ Payload) error {
+	return nil
+}


### PR DESCRIPTION
The main use of this backend is to disable error reporting in
development and test environments.

This is one way to address #7 though I've avoided making any changes based on the environment since I think that should be left up to anyone using the library.