### PR TITLE
Add Go 1.5 and 1.6 to build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: go
 install: make deps
 go:
   - 1.4
+  - 1.5
+  - 1.6
   - tip


### PR DESCRIPTION
I've left 1.4 in the build matrix as some users may still be using it
because of the regression in build times of 1.5 and 1.6.