### PR TITLE
Typo in the example of using NewNullBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ honeybadger.BeforeNotify(
 #### Examples:
 
 ```go
-honeybadger.Configure(honeybadger.Configuration{backend: honeybadger.NewNullBackend()})
+honeybadger.Configure(honeybadger.Configuration{Backend: honeybadger.NewNullBackend()})
 ```
 
 ---


### PR DESCRIPTION
Typo in the Readme file when describes  the `honeybadger.NewNullBackend`