### PR TITLE
Flush notices on panic fixes #27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 install: make deps
 go:
-  - 1.4
-  - 1.5
-  - 1.6
+  - 1.7
   - tip

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ deps:
 	# dependencies
 	go get github.com/pborman/uuid
 	go get github.com/shirou/gopsutil/load
+	go get golang.org/x/sys/unix
 	# testing libs
 	go get github.com/stretchr/testify/mock
 	go get github.com/stretchr/testify/assert

--- a/client.go
+++ b/client.go
@@ -78,6 +78,7 @@ func (client *Client) Notify(err interface{}, extra ...interface{}) (string, err
 func (client *Client) Monitor() {
 	if err := recover(); err != nil {
 		client.Notify(newError(err, 2))
+		client.Flush()
 		panic(err)
 	}
 }

--- a/honeybadger.go
+++ b/honeybadger.go
@@ -83,6 +83,7 @@ func Notify(err interface{}, extra ...interface{}) (string, error) {
 func Monitor() {
 	if err := recover(); err != nil {
 		DefaultClient.Notify(newError(err, 2))
+		DefaultClient.Flush()
 		panic(err)
 	}
 }

--- a/honeybadger_test.go
+++ b/honeybadger_test.go
@@ -169,6 +169,25 @@ func TestNotifyWithFingerprint(t *testing.T) {
 	}
 }
 
+func TestMonitor(t *testing.T) {
+	setup(t)
+	defer teardown()
+
+	defer func() {
+		_ = recover()
+
+		if !testRequestCount(t, 1) {
+			return
+		}
+
+		testNoticePayload(t, requests[0].decodeJSON())
+	}()
+
+	defer Monitor()
+
+	panic("Cobras!")
+}
+
 func TestNotifyWithHandler(t *testing.T) {
 	setup(t)
 	defer teardown()


### PR DESCRIPTION
# Problem
Documentation suggests capturing unhandled panics as such:
```
func main() {
  defer honeybadger.Monitor()
  // ... Exploding code here ...
}
```

However, the `Monitor()` function will often re-raise the panic's error and exit the application before it can be sent by the backend, since that happens asynchronously.

# Solution
Force notices to `Flush()` before re-raising.