### PR TITLE
Make SetContext atomic

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ type noticeHandler func(*Notice) error
 // the configuration and implements the public API.
 type Client struct {
 	Config               *Configuration
-	context              *Context
+	context              *contextSync
 	worker               worker
 	beforeNotifyHandlers []noticeHandler
 }
@@ -53,7 +53,7 @@ func (client *Client) BeforeNotify(handler func(notice *Notice) error) {
 
 // Notify reports the error err to the Honeybadger service.
 func (client *Client) Notify(err interface{}, extra ...interface{}) (string, error) {
-	extra = append([]interface{}{*client.context}, extra...)
+	extra = append([]interface{}{client.context.internal}, extra...)
 	notice := newNotice(client.Config, newError(err, 2), extra...)
 	for _, handler := range client.beforeNotifyHandlers {
 		if err := handler(notice); err != nil {
@@ -131,7 +131,7 @@ func New(c Configuration) *Client {
 	client := Client{
 		Config:  config,
 		worker:  worker,
-		context: &Context{},
+		context: newContextSync(),
 	}
 
 	return &client

--- a/client_test.go
+++ b/client_test.go
@@ -62,7 +62,7 @@ func TestClientConcurrentContext(t *testing.T) {
 	context := client.context.internal
 
 	if context["foo"] != "bar" {
-		t.Errorf("Expected notice to contain context. expected=%#v result=%#v", "bar", context["foo"])
+		t.Errorf("Expected context value. expected=%#v result=%#v", "bar", context["foo"])
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,9 @@
 package honeybadger
 
-import "testing"
+import (
+	"testing"
+	"sync"
+)
 
 func TestNewConfig(t *testing.T) {
 	client := New(Configuration{APIKey: "lemmings"})
@@ -28,10 +31,11 @@ func TestConfigureClientEndpoint(t *testing.T) {
 
 func TestClientContext(t *testing.T) {
 	client := New(Configuration{})
-	client.context = &Context{"foo": "bar"}
 
+	client.SetContext(Context{"foo": "bar"})
 	client.SetContext(Context{"bar": "baz"})
-	context := *client.context
+
+	context := client.context.internal
 
 	if context["foo"] != "bar" {
 		t.Errorf("Expected client to merge global context. expected=%#v actual=%#v", "bar", context["foo"])
@@ -40,4 +44,29 @@ func TestClientContext(t *testing.T) {
 	if context["bar"] != "baz" {
 		t.Errorf("Expected client to merge global context. expected=%#v actual=%#v", "baz", context["bar"])
 	}
+}
+
+func TestClientConcurrentContext(t *testing.T) {
+	var wg sync.WaitGroup
+
+	client     := New(Configuration{})
+	newContext := Context{"foo":"bar"}
+
+	wg.Add(2)
+
+	go updateContext(&wg, client, newContext)
+	go updateContext(&wg, client, newContext)
+
+	wg.Wait()
+
+	context := client.context.internal
+
+	if context["foo"] != "bar" {
+		t.Errorf("Expected notice to contain context. expected=%#v result=%#v", "bar", context["foo"])
+	}
+}
+
+func updateContext(wg *sync.WaitGroup, client *Client, context Context) {
+	client.SetContext(context)
+	wg.Done()
 }

--- a/context_sync.go
+++ b/context_sync.go
@@ -1,0 +1,22 @@
+package honeybadger
+
+import "sync"
+
+type contextSync struct {
+	sync.RWMutex
+	internal Context
+}
+
+func (context *contextSync) Update(other Context) {
+	context.Lock()
+	context.internal.Update(other)
+	context.Unlock()
+}
+
+func newContextSync() *contextSync {
+	instance := contextSync{
+		internal: Context{},
+	}
+
+	return &instance
+}

--- a/context_sync_test.go
+++ b/context_sync_test.go
@@ -21,7 +21,7 @@ func TestContextSync(t *testing.T) {
 	context := instance.internal
 
 	if context["foo"] != "bar" {
-		t.Errorf("Expected notice to contain context. expected=%#v result=%#v", "bar", context["foo"])
+		t.Errorf("Expected context value. expected=%#v result=%#v", "bar", context["foo"])
 	}
 }
 

--- a/context_sync_test.go
+++ b/context_sync_test.go
@@ -1,0 +1,31 @@
+package honeybadger
+
+import (
+	"testing"
+	"sync"
+)
+
+func TestContextSync(t *testing.T) {
+	var wg sync.WaitGroup
+
+	instance   := newContextSync()
+	newContext := Context{"foo":"bar"}
+
+	wg.Add(2)
+
+	go update(&wg, instance, newContext)
+	go update(&wg, instance, newContext)
+
+	wg.Wait()
+
+	context := instance.internal
+
+	if context["foo"] != "bar" {
+		t.Errorf("Expected notice to contain context. expected=%#v result=%#v", "bar", context["foo"])
+	}
+}
+
+func update(wg *sync.WaitGroup, instance *contextSync, context Context) {
+	instance.Update(context)
+	wg.Done()
+}

--- a/notice_test.go
+++ b/notice_test.go
@@ -52,6 +52,11 @@ func TestNewNotice(t *testing.T) {
 	if notice.Backtrace[0].File != "/path/to/root/badgers.go" {
 		t.Errorf("Expected notice not to trash project root. expected=%#v result=%#v", "/path/to/root/badgers.go", notice.Backtrace[0].File)
 	}
+
+	notice = newNotice(&Configuration{}, err, Context{"foo":"bar"})
+	if notice.Context["foo"] != "bar" {
+		t.Errorf("Expected notice to contain context. expected=%#v result=%#v", "bar", notice.Context["foo"])
+	}
 }
 
 func TestToJSON(t *testing.T) {


### PR DESCRIPTION
I think this should fix #31:

> This allows concurrent goroutines to call `honeybadger.SetContext`. It
> does not make `context.Update` safe/atomic because for ease of use,
> `Context` must function as a normal map. This means any client code
> which calls `context.Update` directly should perform its own locking if
> necessary; this may be a case for making `context.Update` a private
> method, since it's not really meant to be used directly anyway.

Closes #31 

cc @evt @pauldub @odarriba