### PR TITLE
Context based error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To report an error manually, use `honeybadger.Notify`:
 
 ```go
 if err != nil {
-  honeybadger.Notify(err)
+  honeybadger.Notify(ctx, err)
 }
 ```
 
@@ -113,7 +113,7 @@ The following options are available to you:
 
 ## Public Interface
 
-### `honeybadger.Notify()`: Send an error to Honeybadger.
+### `honeybadger.Notify(context,Context, interface{}, ...interface{})`: Send an error to Honeybadger.
 
 If you've handled a panic in your code, but would still like to report the error to Honeybadger, this is the method for you. 
 
@@ -121,7 +121,7 @@ If you've handled a panic in your code, but would still like to report the error
 
 ```go
 if err != nil {
-  honeybadger.Notify(err)
+  honeybadger.Notify(ctx, err)
 }
 ```
 
@@ -129,7 +129,7 @@ You can also add local context using an optional second argument when calling
 `honeybadger.Notify`:
 
 ```go
-honeybadger.Notify(err, honeybadger.Context{"user_id": 2})
+honeybadger.Notify(ctx, err, honeybadger.Context{"user_id": 2})
 ```
 
 Honeybadger uses the error's class name to group similar errors together. If
@@ -137,26 +137,26 @@ your error classes are often generic (such as `errors.errorString`), you can
 improve grouping by overriding the default with something more unique:
 
 ```go
-honeybadger.Notify(err, honeybadger.ErrorClass{"CustomClassName"})
+honeybadger.Notify(ctx, err, honeybadger.ErrorClass{"CustomClassName"})
 ```
 
 To override grouping entirely, you can send a custom fingerprint. All errors
 with the same fingerprint will be grouped together:
 
 ```go
-honeybadger.Notify(err, honeybadger.Fingerprint{"A unique string"})
+honeybadger.Notify(ctx, err, honeybadger.Fingerprint{"A unique string"})
 ```
 
 To tag errors in Honeybadger:
 
 ```go
-honeybadger.Notify(err, honeybadger.Tags{"timeout", "http"})
+honeybadger.Notify(ctx, err, honeybadger.Tags{"timeout", "http"})
 ```
 
 ---
 
 
-### `honeybadger.SetContext()`: Set metadata to be sent if an error occurs
+### `honeybadger.SetContext(context.Context, map[string]interface{})`: Set metadata to be sent if an error occurs
 
 This method lets you set context data that will be sent if an error should occur.
 
@@ -167,7 +167,7 @@ For example, it's often useful to record the current user's ID when an error occ
 #### Examples:
 
 ```go
-honeybadger.SetContext(honeybadger.Context{
+honeybadger.SetContext(ctx, honeybadger.Context{
   "user_id": 1,
 })
 ```

--- a/client.go
+++ b/client.go
@@ -118,7 +118,7 @@ func (client *Client) Handler(h http.Handler) http.Handler {
 	}
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		ctx = SetContext(ctx, map[string]interface{}{
+		ctx = client.SetContext(ctx, map[string]interface{}{
 			"path":           r.URL.String(),
 			"host":           r.Host,
 			"header":         r.Header,

--- a/client.go
+++ b/client.go
@@ -103,9 +103,9 @@ func (client *Client) Notify(ctx context.Context, err interface{}, extra ...inte
 
 // Monitor automatically reports panics which occur in the function it's called
 // from. Must be deferred.
-func (client *Client) Monitor() {
+func (client *Client) Monitor(ctx context.Context) {
 	if err := recover(); err != nil {
-		client.Notify(newError(err, 2))
+		client.Notify(ctx, newError(err, 2))
 		client.Flush()
 		panic(err)
 	}

--- a/client.go
+++ b/client.go
@@ -1,11 +1,14 @@
 package honeybadger
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 )
 
 const honeybadgerCtxKey = "honeybadger-go-ctx"
+
+var noCastErr = fmt.Errorf("unable to cast value from context properly")
 
 // The Payload interface is implemented by any type which can be handled by the
 // Backend interface.

--- a/client.go
+++ b/client.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const honeybadgerCtxKey = "honeybadger-go-ctx"
+
 // The Payload interface is implemented by any type which can be handled by the
 // Backend interface.
 type Payload interface {

--- a/client.go
+++ b/client.go
@@ -29,7 +29,6 @@ type noticeHandler func(*Notice) error
 // the configuration and implements the public API.
 type Client struct {
 	Config               *Configuration
-	context              *contextSync
 	worker               worker
 	beforeNotifyHandlers []noticeHandler
 }
@@ -135,9 +134,8 @@ func New(c Configuration) *Client {
 	worker := newBufferedWorker(config)
 
 	client := Client{
-		Config:  config,
-		worker:  worker,
-		context: newContextSync(),
+		Config: config,
+		worker: worker,
 	}
 
 	return &client

--- a/client.go
+++ b/client.go
@@ -119,7 +119,7 @@ func (client *Client) Handler(h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := recover(); err != nil {
-				client.Notify(newError(err, 2), Params(r.Form), getCGIData(r), *r.URL)
+				client.Notify(r.Context(), newError(err, 2), Params(r.Form), getCGIData(r), *r.URL)
 				panic(err)
 			}
 		}()

--- a/client_test.go
+++ b/client_test.go
@@ -3,8 +3,6 @@ package honeybadger
 import (
 	"context"
 	"testing"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -45,7 +43,6 @@ func TestClientContext(t *testing.T) {
 	}
 
 	if context == nil {
-		spew.Dump(ctx)
 		t.Errorf("context value not placed in context.Context")
 		t.FailNow()
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/seanhagen/honeybadger-go
+
+require (
+	github.com/gofrs/uuid/v3 v3.1.2
+	github.com/shirou/gopsutil v2.18.12+incompatible
+	golang.org/x/sys v0.0.0-20190102155601-82a175fd1598 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/gofrs/uuid/v3 v3.1.2 h1:V3IBv1oU82x6YIr5txe3azVHgmOKYdyKQTowm9moBlY=
+github.com/gofrs/uuid/v3 v3.1.2/go.mod h1:xPwMqoocQ1L5G6pXX5BcE7N5jlzn2o19oqAKxwZW/kI=
+github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=
+github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+golang.org/x/sys v0.0.0-20190102155601-82a175fd1598 h1:S8GOgffXV1X3fpVG442QRfWOt0iFl79eHJ7OPt725bo=
+golang.org/x/sys v0.0.0-20190102155601-82a175fd1598/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/honeybadger.go
+++ b/honeybadger.go
@@ -8,7 +8,7 @@ import (
 )
 
 // VERSION defines the version of the honeybadger package.
-const VERSION = "0.4.0"
+const VERSION = "0.5.0"
 
 var (
 	// client is a pre-defined "global" client.

--- a/honeybadger.go
+++ b/honeybadger.go
@@ -55,8 +55,8 @@ func Configure(c Configuration) {
 }
 
 // SetContext merges c Context into the Context of the global client.
-func SetContext(c Context) {
-	DefaultClient.SetContext(c)
+func SetContext(ctx context.Context, c Context) context.Context {
+	return DefaultClient.SetContext(ctx, c)
 }
 
 // Notify reports the error err to the Honeybadger service.
@@ -66,8 +66,8 @@ func SetContext(c Context) {
 //
 // It returns a string UUID which can be used to reference the error from the
 // Honeybadger service, and an error as a second argument.
-func Notify(err interface{}, extra ...interface{}) (string, error) {
-	return DefaultClient.Notify(newError(err, 2), extra...)
+func Notify(ctx context.Context, err interface{}, extra ...interface{}) (string, error) {
+	return DefaultClient.Notify(ctx, newError(err, 2), extra...)
 }
 
 // Monitor is used to automatically notify Honeybadger service of panics which

--- a/honeybadger.go
+++ b/honeybadger.go
@@ -118,6 +118,8 @@ func Flush() {
 
 // Handler returns an http.Handler function which automatically reports panics
 // to Honeybadger and then re-panics.
+//
+// The request context is what's passed to notify.
 func Handler(h http.Handler) http.Handler {
 	return DefaultClient.Handler(h)
 }

--- a/honeybadger.go
+++ b/honeybadger.go
@@ -1,6 +1,7 @@
 package honeybadger
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"

--- a/honeybadger_test.go
+++ b/honeybadger_test.go
@@ -1,6 +1,7 @@
 package honeybadger
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,7 +86,9 @@ func TestNotify(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	res, _ := Notify(errors.New("Cobras!"))
+	ctx := context.Background()
+
+	res, _ := Notify(ctx, errors.New("Cobras!"))
 
 	if uuid.Parse(res) == nil {
 		t.Errorf("Expected Notify() to return a UUID. actual=%#v", res)
@@ -104,8 +107,9 @@ func TestNotifyWithContext(t *testing.T) {
 	setup(t)
 	defer teardown()
 
+	ctx := context.Background()
 	context := Context{"foo": "bar"}
-	Notify("Cobras!", context)
+	Notify(ctx, "Cobras!", context)
 	Flush()
 
 	if !testRequestCount(t, 1) {
@@ -124,7 +128,8 @@ func TestNotifyWithErrorClass(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	Notify("Cobras!", ErrorClass{"Badgers"})
+	ctx := context.Background()
+	Notify(ctx, "Cobras!", ErrorClass{"Badgers"})
 	Flush()
 
 	if !testRequestCount(t, 1) {
@@ -149,7 +154,8 @@ func TestNotifyWithTags(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	Notify("Cobras!", Tags{"timeout", "http"})
+	ctx := context.Background()
+	Notify(ctx, "Cobras!", Tags{"timeout", "http"})
 	Flush()
 
 	if !testRequestCount(t, 1) {
@@ -174,7 +180,8 @@ func TestNotifyWithFingerprint(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	Notify("Cobras!", Fingerprint{"Badgers"})
+	ctx := context.Background()
+	Notify(ctx, "Cobras!", Fingerprint{"Badgers"})
 	Flush()
 
 	if !testRequestCount(t, 1) {
@@ -222,7 +229,8 @@ func TestNotifyWithHandler(t *testing.T) {
 		n.Fingerprint = "foo bar baz"
 		return nil
 	})
-	Notify(errors.New("Cobras!"))
+	ctx := context.Background()
+	Notify(ctx, errors.New("Cobras!"))
 	Flush()
 
 	payload := requests[0].decodeJSON()
@@ -248,7 +256,8 @@ func TestNotifyWithHandlerError(t *testing.T) {
 	BeforeNotify(func(n *Notice) error {
 		return err
 	})
-	_, notifyErr := Notify(errors.New("Cobras!"))
+	ctx := context.Background()
+	_, notifyErr := Notify(ctx, errors.New("Cobras!"))
 	Flush()
 
 	if !testRequestCount(t, 0) {

--- a/notice.go
+++ b/notice.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/pborman/uuid"
+	"github.com/gofrs/uuid/v3"
 	"github.com/shirou/gopsutil/load"
 	"github.com/shirou/gopsutil/mem"
 )
@@ -143,10 +143,12 @@ func composeStack(stack []*Frame, root string) (frames []*Frame) {
 }
 
 func newNotice(config *Configuration, err Error, extra ...interface{}) *Notice {
+	tkn, _ := uuid.NewV4()
+
 	notice := Notice{
 		APIKey:       config.APIKey,
 		Error:        err,
-		Token:        uuid.NewRandom().String(),
+		Token:        tkn.String(),
 		ErrorMessage: err.Message,
 		ErrorClass:   err.Class,
 		Env:          config.Env,


### PR DESCRIPTION
**Update `Client.SetContext` to require `context.Context`**
To keep the Honeybadger context scoped to a single request, store
the `*contextSync` value in a `context.Context`. This way there's no possibility
of the request context data being overwritten due to the function being called
in a concurrent setting.

**Update `Client.Notify` to require `context.Context`**
In order to get the context stored in the `Client.SetContext` call, need to
require a context as the first argument.

**Update Monitor to require `context.Context`**
Same as other functions, `client.Notify` requires a `context.Context` as the
first argument so Monitor has to be updated as well. Does mean that a panic
won't have the context information unless it's called within the function that
might panic instead of at the top level.

Ie:

```
func main(){
  defer honeybadger.Monitor()
  // set up http handlers and whatnot
}
```

Won't be able to get the values set unless it's called like so:

```
func handler(w http.ResponseWriter, r *http.Request){
  defer honeybadger.MonitorCtx(r.Context())
  // rest of handler
}
```

**No more need for `Client.context`, so removing it**

**Update `Client.Handler` to use `r.Context()`**

**Update functions to require `context.Context`**

**Use `context.Background` in `Monitor()`**

**Version bump -- v0.5.0**

