### PR TITLE
fix: implement go1.13 error chains Unwrap method

### DIFF
--- a/error.go
+++ b/error.go
@@ -18,10 +18,14 @@ type Frame struct {
 
 // Error provides more structured information about a Go error.
 type Error struct {
-	err     interface{}
+	err     error
 	Message string
 	Class   string
 	Stack   []*Frame
+}
+
+func (e Error) Unwrap() error {
+	return e.err
 }
 
 func (e Error) Error() string {


### PR DESCRIPTION
## Status

**READY**

## Description
Fixes #48 : Better interopt with golang errors. addresses main problem in #48.
