### PR TITLE
feat: allow errors to provide their own stack traces

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -1,6 +1,8 @@
 package honeybadger
 
 import (
+	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -30,6 +32,55 @@ func TestNewErrorTrace(t *testing.T) {
 	for i, suffix := range expected {
 		method := err.Stack[i].Method
 
+		if !strings.HasSuffix(method, suffix) {
+			// Logs the stack to give some context about the error
+			for j, stack := range err.Stack {
+				t.Logf("%d: %s", j, stack.Method)
+			}
+
+			t.Fatalf("stack[%d].Method expected_suffix=%q actual=%q", i, suffix, method)
+		}
+	}
+}
+
+type customerror struct {
+	error
+	callers []uintptr
+}
+
+func (t customerror) Callers() []uintptr {
+	return t.callers
+}
+
+func newcustomerror() customerror {
+	stack := make([]uintptr, maxFrames)
+	length := runtime.Callers(1, stack[:])
+	return customerror{
+		error:   fmt.Errorf("hello world"),
+		callers: stack[:length],
+	}
+}
+
+func TestNewErrorCustomTrace(t *testing.T) {
+	err := NewError(newcustomerror())
+
+	// The stack should look like this:
+	//   github.com/honeybadger-io/honeybadger-go.newcustomerror
+	//   github.com/honeybadger-io/honeybadger-go.TestNewErrorCustomTrace
+	//   testing.tRunner
+	//   runtime.goexit
+	if len(err.Stack) < 3 {
+		t.Errorf("Expected to generate full trace")
+	}
+
+	// Checks that the top top methods are the (inlined) fn and the test Method
+	expected := []string{
+		".newcustomerror",
+		".TestNewErrorCustomTrace",
+	}
+
+	for i, suffix := range expected {
+		method := err.Stack[i].Method
 		if !strings.HasSuffix(method, suffix) {
 			// Logs the stack to give some context about the error
 			for j, stack := range err.Stack {


### PR DESCRIPTION
## Status
**READY**

## Description
this allows errors to report their actual stack trace without requiring honeybadger to be used to generate the error. related #48.

minor note: not my ideal approach due to the lack of standardization in the ecosystem for this but its a starting point.


## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
