### PR TITLE
chore: update zerolog to use v0.9.0

### DIFF
--- a/zerolog/go.mod
+++ b/zerolog/go.mod
@@ -3,7 +3,7 @@ module github.com/honeybadger-io/honeybadger-go/zerolog
 go 1.24.0
 
 require (
-	github.com/honeybadger-io/honeybadger-go v0.8.1-0.20251117195949-88d06c1beac2
+	github.com/honeybadger-io/honeybadger-go v0.9.0
 	github.com/rs/zerolog v1.33.0
 )
 

--- a/zerolog/go.sum
+++ b/zerolog/go.sum
@@ -6,6 +6,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/honeybadger-io/honeybadger-go v0.9.0 h1:e8m+V0D22kCMJru+oLoiLQDSehNmM9xoBQrM6d0sR/g=
+github.com/honeybadger-io/honeybadger-go v0.9.0/go.mod h1:6pi6SE4Usxbe614bpuLY+UbOOvtfMATyZhLvrg6WBQM=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=


### PR DESCRIPTION
Update zerolog sub-package to reference v0.9.0

If squashing, I think the commit message must start with `chore:` or it will attempt to cut another release. I will also have to manually push the `zerolog/v0.9.0` tag, which is required for go mod lookups.